### PR TITLE
Handle Reopen label

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: "FlightBot"
 
 on: 
+  issues:
+    types: [reopened]
   pull_request:
     types: [opened, edited, ready_for_review, review_requested]
   pull_request_review:
@@ -20,3 +22,4 @@ jobs:
           review-trigger: "please review"
           merge-label: "5: Ready for merge"
           review-label: "6: PR for review"
+          reopen-label: "Reopen"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           review-trigger: "please review"
+          staging-label: "4: Staging"
           merge-label: "5: Ready for merge"
           review-label: "6: PR for review"
           reopen-label: "Reopen"

--- a/action.yml
+++ b/action.yml
@@ -13,6 +13,9 @@ inputs:
   review-label:
     description: 'The name of the review label'
     default: '6: PR for review'
+  reopen-label:
+    description: 'The name of the reopen label'
+    default: 'Reopen'
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,9 @@ inputs:
   review-trigger:
     description: 'The string that triggers the review label'
     default: 'please review'
+  staging-label:
+    description: 'The name of the staging label'
+    default: '4: Staging'
   merge-label:
     description: 'The name of the merge label'
     default: '5: Ready for merge'

--- a/dist/index.js
+++ b/dist/index.js
@@ -8528,10 +8528,6 @@ function run() {
             const context = github.context;
             const payload = context.payload;
             logDebuggingInfo(context);
-            if (!payload.pull_request) {
-                console.log("No payload pull request. Exiting...");
-                return;
-            }
             const token = Object(core.getInput)("repo-token", { required: true });
             const client = new github.GitHub(token);
             // Handle events
@@ -8568,7 +8564,7 @@ function handlePullRequestEvent(client, payload) {
         const reopenLabel = Object(core.getInput)("reopen-label", { required: true });
         const prBody = payload.pull_request.body.toLowerCase();
         if (PR_TEXT_EDITED_ACTIONS.includes(payload.action) && prBody.includes(reviewTrigger.toLowerCase())) {
-            console.log(`Found review trigger '${reviewTrigger}' in PR body. Adding review label...`);
+            console.log(`Found review trigger '${reviewTrigger}' in PR body. Adding review label and removing reopen label...`);
             yield labelPRAndLinkedIssues(client, payload, reviewLabel);
             yield removeLabelFromLinkedIssues(client, payload, reopenLabel);
             return;
@@ -8602,7 +8598,7 @@ function handleIssuesEvent(client, payload) {
         const mergeLabel = Object(core.getInput)("merge-label", { required: true });
         const reopenLabel = Object(core.getInput)("reopen-label", { required: true });
         if (payload.action == REOPENED_TYPE) {
-            console.log(`Previous review dismissed. Adding review label...`);
+            console.log(`Issue ${payload.issue.number} was reopened. Added reopen label and removing review and merge labels...`);
             yield removeLabel(client, payload.issue.number, reviewLabel);
             yield removeLabel(client, payload.issue.number, mergeLabel);
             yield addLabels(client, payload.issue.number, [reopenLabel]);

--- a/dist/index.js
+++ b/dist/index.js
@@ -8567,7 +8567,6 @@ function handlePullRequestEvent(client, payload) {
             return;
         }
         const reviewTrigger = Object(core.getInput)(REVIEW_TRIGGER, { required: true });
-        const reopenLabel = Object(core.getInput)(REOPEN_LABEL, { required: true });
         const prBody = payload.pull_request.body.toLowerCase();
         if (PR_TEXT_EDITED_ACTIONS.includes(payload.action) && prBody.includes(reviewTrigger.toLowerCase())) {
             console.log(`Found review trigger '${reviewTrigger}' in PR body. Adding review label...`);
@@ -8604,7 +8603,7 @@ function handleIssuesEvent(client, payload) {
         const reopenLabel = Object(core.getInput)(REOPEN_LABEL, { required: true });
         const stagingLabel = Object(core.getInput)(STAGING_LABEL, { required: true });
         if (payload.action == REOPENED_TYPE) {
-            console.log(`Issue ${payload.issue.number} was reopened. Added reopen label and removing review and merge labels...`);
+            console.log(`Issue ${payload.issue.number} was reopened. Added reopen label and removing review, merge and staging labels...`);
             yield removeLabel(client, payload.issue.number, reviewLabel);
             yield removeLabel(client, payload.issue.number, mergeLabel);
             yield removeLabel(client, payload.issue.number, stagingLabel);

--- a/index.ts
+++ b/index.ts
@@ -30,10 +30,6 @@ async function run() {
     const context = github.context;
     const payload = context.payload;
     logDebuggingInfo(context);
-    if (!payload.pull_request) {
-      console.log("No payload pull request. Exiting...");
-      return;
-    }
     const token = core.getInput("repo-token", { required: true });
     const client = new github.GitHub(token);
 
@@ -70,7 +66,7 @@ async function handlePullRequestEvent(client: github.GitHub, payload: WebhookPay
   const reopenLabel = core.getInput("reopen-label", { required: true });
   const prBody = payload.pull_request.body.toLowerCase();
   if (PR_TEXT_EDITED_ACTIONS.includes(payload.action) && prBody.includes(reviewTrigger.toLowerCase())) {
-    console.log(`Found review trigger '${reviewTrigger}' in PR body. Adding review label...`);
+    console.log(`Found review trigger '${reviewTrigger}' in PR body. Adding review label and removing reopen label...`);
     await labelPRAndLinkedIssues(client, payload, reviewLabel);
     await removeLabelFromLinkedIssues(client, payload, reopenLabel);
     return;
@@ -106,7 +102,7 @@ async function handleIssuesEvent(client: github.GitHub, payload: WebhookPayload)
   const reopenLabel = core.getInput("reopen-label", { required: true });
 
   if (payload.action == REOPENED_TYPE) {
-    console.log(`Previous review dismissed. Adding review label...`);
+    console.log(`Issue ${payload.issue.number} was reopened. Added reopen label and removing review and merge labels...`);
     await removeLabel(client, payload.issue.number, reviewLabel);
     await removeLabel(client, payload.issue.number, mergeLabel);
     await addLabels(client, payload.issue.number, [reopenLabel]);

--- a/index.ts
+++ b/index.ts
@@ -47,7 +47,7 @@ async function run() {
       await handlePullRequestReviewEvent(client, payload);
     } else if (context.eventName == ISSUES_EVENT) {
       await handleIssuesEvent(client, payload);
-    } 
+    }
   } catch (error) {
     core.error(error);
     core.setFailed(error.message);
@@ -70,7 +70,6 @@ async function handlePullRequestEvent(client: github.GitHub, payload: WebhookPay
   }
 
   const reviewTrigger = core.getInput(REVIEW_TRIGGER, { required: true });
-  const reopenLabel = core.getInput(REOPEN_LABEL, { required: true });
   const prBody = payload.pull_request.body.toLowerCase();
   if (PR_TEXT_EDITED_ACTIONS.includes(payload.action) && prBody.includes(reviewTrigger.toLowerCase())) {
     console.log(`Found review trigger '${reviewTrigger}' in PR body. Adding review label...`);
@@ -109,14 +108,13 @@ async function handleIssuesEvent(client: github.GitHub, payload: WebhookPayload)
   const stagingLabel = core.getInput(STAGING_LABEL, { required: true });
 
   if (payload.action == REOPENED_TYPE) {
-    console.log(`Issue ${payload.issue.number} was reopened. Added reopen label and removing review and merge labels...`);
+    console.log(`Issue ${payload.issue.number} was reopened. Added reopen label and removing review, merge and staging labels...`);
     await removeLabel(client, payload.issue.number, reviewLabel);
     await removeLabel(client, payload.issue.number, mergeLabel);
     await removeLabel(client, payload.issue.number, stagingLabel);
     await addLabels(client, payload.issue.number, [reopenLabel]);
     return;
   }
-
 }
 
 function logDebuggingInfo(context: any) {

--- a/labeler.ts
+++ b/labeler.ts
@@ -17,9 +17,14 @@ export async function labelPRAndLinkedIssues(client: github.GitHub, payload: Web
 
 export async function removeLabelFromPRAndLinkedIssues(client: github.GitHub, payload: WebhookPayload, label: string) {
   const pullRequest = payload.pull_request;
-  const linkedIssues = getLinkedIssues(pullRequest.body);
   console.log(`Removing '${label}' label from PR: ${pullRequest.number}...`);
   await removeLabel(client, pullRequest.number, label);
+  removeLabelFromLinkedIssues(client, payload, label)
+}
+
+export async function removeLabelFromLinkedIssues(client: github.GitHub, payload: WebhookPayload, label: string) {
+  const pullRequest = payload.pull_request;
+  const linkedIssues = getLinkedIssues(pullRequest.body);
   linkedIssues.forEach(async value => {
     console.log(`Removing '${label}' label from issue: ${value}...`);
     await removeLabel(client, value, label);


### PR DESCRIPTION
## Notes for review

It is a little difficult to test this as the new action code does not run on the issues in this repo. This repo uses the version of the action that is on master.

One downside to this solution is that is it pretty slow because the action is queued up. A user might be worried that the action is not working and just apply the labels themselves.

I've tested the code in a repo on my personal account: https://github.com/Jensenks/FlightLoggerLabelAction

[Here is a test issue](https://github.com/Jensenks/FlightLoggerLabelAction/issues/7) that I've closed, reopened and opened a new PR to fix:
![billede](https://user-images.githubusercontent.com/6094464/85031280-c22dd280-b17e-11ea-99a3-eabc36abf502.png)

[Here is the related PR](https://github.com/Jensenks/FlightLoggerLabelAction/pull/9)
![billede](https://user-images.githubusercontent.com/6094464/85031426-f43f3480-b17e-11ea-8f9e-5c7dd52ad173.png)

fixes #10

please review