### PR TITLE
Skip applying review label to draft PRs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 node_modules/
 lib/
+.idea/

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,7 +1,7 @@
 /******/ (() => { // webpackBootstrap
 /******/ 	var __webpack_modules__ = ({
 
-/***/ 3826:
+/***/ 9544:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -100,7 +100,7 @@ function escapeProperty(s) {
 
 /***/ }),
 
-/***/ 1836:
+/***/ 4406:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -122,7 +122,7 @@ var __importStar = (this && this.__importStar) || function (mod) {
     return result;
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
-const command_1 = __nccwpck_require__(3826);
+const command_1 = __nccwpck_require__(9544);
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 /**
@@ -329,7 +329,7 @@ exports.getState = getState;
 
 /***/ }),
 
-/***/ 2064:
+/***/ 8186:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -382,7 +382,7 @@ exports.Context = Context;
 
 /***/ }),
 
-/***/ 5404:
+/***/ 190:
 /***/ (function(__unused_webpack_module, exports, __nccwpck_require__) {
 
 "use strict";
@@ -396,10 +396,10 @@ var __importStar = (this && this.__importStar) || function (mod) {
 };
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 // Originally pulled from https://github.com/JasonEtco/actions-toolkit/blob/master/src/github.ts
-const graphql_1 = __nccwpck_require__(9943);
-const rest_1 = __nccwpck_require__(8732);
-const Context = __importStar(__nccwpck_require__(2064));
-const httpClient = __importStar(__nccwpck_require__(3136));
+const graphql_1 = __nccwpck_require__(5821);
+const rest_1 = __nccwpck_require__(4270);
+const Context = __importStar(__nccwpck_require__(8186));
+const httpClient = __importStar(__nccwpck_require__(3430));
 // We need this in order to extend Octokit
 rest_1.Octokit.prototype = new rest_1.Octokit();
 exports.context = new Context.Context();
@@ -497,7 +497,7 @@ exports.GitHub = GitHub;
 
 /***/ }),
 
-/***/ 3136:
+/***/ 3430:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -506,7 +506,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 const url = __nccwpck_require__(7016);
 const http = __nccwpck_require__(8611);
 const https = __nccwpck_require__(5692);
-const pm = __nccwpck_require__(8336);
+const pm = __nccwpck_require__(6178);
 let tunnel;
 var HttpCodes;
 (function (HttpCodes) {
@@ -916,7 +916,7 @@ class HttpClient {
         if (useProxy) {
             // If using proxy, need tunnel
             if (!tunnel) {
-                tunnel = __nccwpck_require__(4578);
+                tunnel = __nccwpck_require__(2060);
             }
             const agentOptions = {
                 maxSockets: maxSockets,
@@ -1036,7 +1036,7 @@ exports.HttpClient = HttpClient;
 
 /***/ }),
 
-/***/ 8336:
+/***/ 6178:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1102,7 +1102,7 @@ exports.checkBypass = checkBypass;
 
 /***/ }),
 
-/***/ 5864:
+/***/ 134:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1159,7 +1159,7 @@ exports.createTokenAuth = createTokenAuth;
 
 /***/ }),
 
-/***/ 6663:
+/***/ 6549:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1169,8 +1169,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var isPlainObject = _interopDefault(__nccwpck_require__(7427));
-var universalUserAgent = __nccwpck_require__(4435);
+var isPlainObject = _interopDefault(__nccwpck_require__(4313));
+var universalUserAgent = __nccwpck_require__(3189);
 
 function lowercaseKeys(object) {
   if (!object) {
@@ -1546,7 +1546,7 @@ exports.endpoint = endpoint;
 
 /***/ }),
 
-/***/ 9943:
+/***/ 5821:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1554,8 +1554,8 @@ exports.endpoint = endpoint;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var request = __nccwpck_require__(7855);
-var universalUserAgent = __nccwpck_require__(4435);
+var request = __nccwpck_require__(8437);
+var universalUserAgent = __nccwpck_require__(3189);
 
 const VERSION = "4.5.0";
 
@@ -1639,7 +1639,7 @@ exports.withCustomRequest = withCustomRequest;
 
 /***/ }),
 
-/***/ 658:
+/***/ 8436:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1789,7 +1789,7 @@ exports.paginateRest = paginateRest;
 
 /***/ }),
 
-/***/ 1670:
+/***/ 3472:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -1827,7 +1827,7 @@ exports.requestLog = requestLog;
 
 /***/ }),
 
-/***/ 4135:
+/***/ 4933:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -1835,7 +1835,7 @@ exports.requestLog = requestLog;
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 
-var deprecation = __nccwpck_require__(5062);
+var deprecation = __nccwpck_require__(4188);
 
 var endpointsByScope = {
   actions: {
@@ -15031,7 +15031,7 @@ exports.restEndpointMethods = restEndpointMethods;
 
 /***/ }),
 
-/***/ 2268:
+/***/ 2290:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15041,8 +15041,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(5062);
-var once = _interopDefault(__nccwpck_require__(5128));
+var deprecation = __nccwpck_require__(4188);
+var once = _interopDefault(__nccwpck_require__(5874));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -15094,7 +15094,7 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 7855:
+/***/ 8437:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15104,11 +15104,11 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var endpoint = __nccwpck_require__(6663);
-var universalUserAgent = __nccwpck_require__(4435);
-var isPlainObject = _interopDefault(__nccwpck_require__(7427));
-var nodeFetch = _interopDefault(__nccwpck_require__(3089));
-var requestError = __nccwpck_require__(2119);
+var endpoint = __nccwpck_require__(6549);
+var universalUserAgent = __nccwpck_require__(3189);
+var isPlainObject = _interopDefault(__nccwpck_require__(4313));
+var nodeFetch = _interopDefault(__nccwpck_require__(1867));
+var requestError = __nccwpck_require__(7045);
 
 const VERSION = "5.4.4";
 
@@ -15250,7 +15250,7 @@ exports.request = request;
 
 /***/ }),
 
-/***/ 2119:
+/***/ 7045:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15260,8 +15260,8 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var deprecation = __nccwpck_require__(5062);
-var once = _interopDefault(__nccwpck_require__(5128));
+var deprecation = __nccwpck_require__(4188);
+var once = _interopDefault(__nccwpck_require__(5874));
 
 const logOnce = once(deprecation => console.warn(deprecation));
 /**
@@ -15313,25 +15313,25 @@ exports.RequestError = RequestError;
 
 /***/ }),
 
-/***/ 8732:
+/***/ 4270:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const { requestLog } = __nccwpck_require__(1670);
+const { requestLog } = __nccwpck_require__(3472);
 const {
   restEndpointMethods
-} = __nccwpck_require__(4135);
+} = __nccwpck_require__(4933);
 
-const Core = __nccwpck_require__(2785);
+const Core = __nccwpck_require__(5239);
 
 const CORE_PLUGINS = [
-  __nccwpck_require__(7924),
-  __nccwpck_require__(6190), // deprecated: remove in v17
+  __nccwpck_require__(5822),
+  __nccwpck_require__(188), // deprecated: remove in v17
   requestLog,
-  __nccwpck_require__(6376),
+  __nccwpck_require__(962),
   restEndpointMethods,
-  __nccwpck_require__(9042),
+  __nccwpck_require__(1280),
 
-  __nccwpck_require__(2259) // deprecated: remove in v17
+  __nccwpck_require__(6501) // deprecated: remove in v17
 ];
 
 const OctokitRest = Core.plugin(CORE_PLUGINS);
@@ -15363,15 +15363,15 @@ module.exports = Octokit;
 
 /***/ }),
 
-/***/ 3292:
+/***/ 3042:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = Octokit;
 
-const { request } = __nccwpck_require__(7855);
-const Hook = __nccwpck_require__(364);
+const { request } = __nccwpck_require__(8437);
+const Hook = __nccwpck_require__(3478);
 
-const parseClientOptions = __nccwpck_require__(9004);
+const parseClientOptions = __nccwpck_require__(6350);
 
 function Octokit(plugins, options) {
   options = options || {};
@@ -15399,23 +15399,23 @@ function Octokit(plugins, options) {
 
 /***/ }),
 
-/***/ 2785:
+/***/ 5239:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-const factory = __nccwpck_require__(5958);
+const factory = __nccwpck_require__(8284);
 
 module.exports = factory();
 
 
 /***/ }),
 
-/***/ 5958:
+/***/ 8284:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = factory;
 
-const Octokit = __nccwpck_require__(3292);
-const registerPlugin = __nccwpck_require__(7515);
+const Octokit = __nccwpck_require__(3042);
+const registerPlugin = __nccwpck_require__(6289);
 
 function factory(plugins) {
   const Api = Octokit.bind(null, plugins || []);
@@ -15426,14 +15426,14 @@ function factory(plugins) {
 
 /***/ }),
 
-/***/ 9004:
+/***/ 6350:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = parseOptions;
 
-const { Deprecation } = __nccwpck_require__(5062);
-const { getUserAgent } = __nccwpck_require__(8263);
-const once = __nccwpck_require__(5128);
+const { Deprecation } = __nccwpck_require__(4188);
+const { getUserAgent } = __nccwpck_require__(2909);
+const once = __nccwpck_require__(5874);
 
 const pkg = __nccwpck_require__(9796);
 
@@ -15522,12 +15522,12 @@ function parseOptions(options, log, hook) {
 
 /***/ }),
 
-/***/ 7515:
+/***/ 6289:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = registerPlugin;
 
-const factory = __nccwpck_require__(5958);
+const factory = __nccwpck_require__(8284);
 
 function registerPlugin(plugins, pluginFunction) {
   return factory(
@@ -15538,7 +15538,7 @@ function registerPlugin(plugins, pluginFunction) {
 
 /***/ }),
 
-/***/ 8263:
+/***/ 2909:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -15548,7 +15548,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var osName = _interopDefault(__nccwpck_require__(630));
+var osName = _interopDefault(__nccwpck_require__(5968));
 
 function getUserAgent() {
   try {
@@ -15568,13 +15568,13 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 6257:
+/***/ 9423:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticate;
 
-const { Deprecation } = __nccwpck_require__(5062);
-const once = __nccwpck_require__(5128);
+const { Deprecation } = __nccwpck_require__(4188);
+const once = __nccwpck_require__(5874);
 
 const deprecateAuthenticate = once((log, deprecation) => log.warn(deprecation));
 
@@ -15627,13 +15627,13 @@ function authenticate(state, options) {
 
 /***/ }),
 
-/***/ 9119:
+/***/ 6917:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationBeforeRequest;
 
-const btoa = __nccwpck_require__(3260);
-const uniq = __nccwpck_require__(6508);
+const btoa = __nccwpck_require__(7753);
+const uniq = __nccwpck_require__(4674);
 
 function authenticationBeforeRequest(state, options) {
   if (!state.auth.type) {
@@ -15677,19 +15677,19 @@ function authenticationBeforeRequest(state, options) {
 
 /***/ }),
 
-/***/ 6190:
+/***/ 188:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationPlugin;
 
-const { Deprecation } = __nccwpck_require__(5062);
-const once = __nccwpck_require__(5128);
+const { Deprecation } = __nccwpck_require__(4188);
+const once = __nccwpck_require__(5874);
 
 const deprecateAuthenticate = once((log, deprecation) => log.warn(deprecation));
 
-const authenticate = __nccwpck_require__(6257);
-const beforeRequest = __nccwpck_require__(9119);
-const requestError = __nccwpck_require__(4348);
+const authenticate = __nccwpck_require__(9423);
+const beforeRequest = __nccwpck_require__(6917);
+const requestError = __nccwpck_require__(2638);
 
 function authenticationPlugin(octokit, options) {
   if (options.auth) {
@@ -15715,12 +15715,12 @@ function authenticationPlugin(octokit, options) {
 
 /***/ }),
 
-/***/ 4348:
+/***/ 2638:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationRequestError;
 
-const { RequestError } = __nccwpck_require__(2268);
+const { RequestError } = __nccwpck_require__(2290);
 
 function authenticationRequestError(state, error, options) {
   /* istanbul ignore next */
@@ -15777,14 +15777,14 @@ function authenticationRequestError(state, error, options) {
 
 /***/ }),
 
-/***/ 9005:
+/***/ 8735:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationBeforeRequest;
 
-const btoa = __nccwpck_require__(3260);
+const btoa = __nccwpck_require__(7753);
 
-const withAuthorizationPrefix = __nccwpck_require__(855);
+const withAuthorizationPrefix = __nccwpck_require__(3933);
 
 function authenticationBeforeRequest(state, options) {
   if (typeof state.auth === "string") {
@@ -15837,19 +15837,19 @@ function authenticationBeforeRequest(state, options) {
 
 /***/ }),
 
-/***/ 7924:
+/***/ 5822:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationPlugin;
 
-const { createTokenAuth } = __nccwpck_require__(5864);
-const { Deprecation } = __nccwpck_require__(5062);
-const once = __nccwpck_require__(5128);
+const { createTokenAuth } = __nccwpck_require__(134);
+const { Deprecation } = __nccwpck_require__(4188);
+const once = __nccwpck_require__(5874);
 
-const beforeRequest = __nccwpck_require__(9005);
-const requestError = __nccwpck_require__(3302);
-const validate = __nccwpck_require__(6260);
-const withAuthorizationPrefix = __nccwpck_require__(855);
+const beforeRequest = __nccwpck_require__(8735);
+const requestError = __nccwpck_require__(4412);
+const validate = __nccwpck_require__(6426);
+const withAuthorizationPrefix = __nccwpck_require__(3933);
 
 const deprecateAuthBasic = once((log, deprecation) => log.warn(deprecation));
 const deprecateAuthObject = once((log, deprecation) => log.warn(deprecation));
@@ -15920,12 +15920,12 @@ function authenticationPlugin(octokit, options) {
 
 /***/ }),
 
-/***/ 3302:
+/***/ 4412:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = authenticationRequestError;
 
-const { RequestError } = __nccwpck_require__(2268);
+const { RequestError } = __nccwpck_require__(2290);
 
 function authenticationRequestError(state, error, options) {
   if (!error.headers) throw error;
@@ -15988,7 +15988,7 @@ function authenticationRequestError(state, error, options) {
 
 /***/ }),
 
-/***/ 6260:
+/***/ 6426:
 /***/ ((module) => {
 
 module.exports = validateAuth;
@@ -16016,12 +16016,12 @@ function validateAuth(auth) {
 
 /***/ }),
 
-/***/ 855:
+/***/ 3933:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = withAuthorizationPrefix;
 
-const atob = __nccwpck_require__(2620);
+const atob = __nccwpck_require__(6486);
 
 const REGEX_IS_BASIC_AUTH = /^[\w-]+:/;
 
@@ -16046,12 +16046,12 @@ function withAuthorizationPrefix(authorization) {
 
 /***/ }),
 
-/***/ 6376:
+/***/ 962:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = paginatePlugin;
 
-const { paginateRest } = __nccwpck_require__(658);
+const { paginateRest } = __nccwpck_require__(8436);
 
 function paginatePlugin(octokit) {
   Object.assign(octokit, paginateRest(octokit));
@@ -16060,12 +16060,12 @@ function paginatePlugin(octokit) {
 
 /***/ }),
 
-/***/ 9042:
+/***/ 1280:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = octokitValidate;
 
-const validate = __nccwpck_require__(2022);
+const validate = __nccwpck_require__(8104);
 
 function octokitValidate(octokit) {
   octokit.hook.before("request", validate.bind(null, octokit));
@@ -16074,7 +16074,7 @@ function octokitValidate(octokit) {
 
 /***/ }),
 
-/***/ 2022:
+/***/ 8104:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -16082,9 +16082,9 @@ function octokitValidate(octokit) {
 
 module.exports = validate;
 
-const { RequestError } = __nccwpck_require__(2268);
-const get = __nccwpck_require__(167);
-const set = __nccwpck_require__(6059);
+const { RequestError } = __nccwpck_require__(2290);
+const get = __nccwpck_require__(3521);
+const set = __nccwpck_require__(4637);
 
 function validate(octokit, options) {
   if (!options.request.validate) {
@@ -16233,7 +16233,7 @@ function validate(octokit, options) {
 
 /***/ }),
 
-/***/ 2620:
+/***/ 6486:
 /***/ ((module) => {
 
 module.exports = function atob(str) {
@@ -16243,12 +16243,12 @@ module.exports = function atob(str) {
 
 /***/ }),
 
-/***/ 364:
+/***/ 3478:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var register = __nccwpck_require__(999)
-var addHook = __nccwpck_require__(2827)
-var removeHook = __nccwpck_require__(1022)
+var register = __nccwpck_require__(1369)
+var addHook = __nccwpck_require__(4097)
+var removeHook = __nccwpck_require__(5004)
 
 // bind with array of arguments: https://stackoverflow.com/a/21792913
 var bind = Function.bind
@@ -16307,7 +16307,7 @@ module.exports.Collection = Hook.Collection
 
 /***/ }),
 
-/***/ 2827:
+/***/ 4097:
 /***/ ((module) => {
 
 module.exports = addHook
@@ -16360,7 +16360,7 @@ function addHook (state, kind, name, hook) {
 
 /***/ }),
 
-/***/ 999:
+/***/ 1369:
 /***/ ((module) => {
 
 module.exports = register
@@ -16395,7 +16395,7 @@ function register (state, name, method, options) {
 
 /***/ }),
 
-/***/ 1022:
+/***/ 5004:
 /***/ ((module) => {
 
 module.exports = removeHook
@@ -16419,7 +16419,7 @@ function removeHook (state, name, method) {
 
 /***/ }),
 
-/***/ 3260:
+/***/ 7753:
 /***/ ((module) => {
 
 module.exports = function btoa(str) {
@@ -16429,15 +16429,15 @@ module.exports = function btoa(str) {
 
 /***/ }),
 
-/***/ 642:
+/***/ 128:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const cp = __nccwpck_require__(5317);
-const parse = __nccwpck_require__(6357);
-const enoent = __nccwpck_require__(7989);
+const parse = __nccwpck_require__(7503);
+const enoent = __nccwpck_require__(9119);
 
 function spawn(command, args, options) {
     // Parse the arguments
@@ -16476,7 +16476,7 @@ module.exports._enoent = enoent;
 
 /***/ }),
 
-/***/ 7989:
+/***/ 9119:
 /***/ ((module) => {
 
 "use strict";
@@ -16543,18 +16543,18 @@ module.exports = {
 
 /***/ }),
 
-/***/ 6357:
+/***/ 7503:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const path = __nccwpck_require__(6928);
-const niceTry = __nccwpck_require__(9224);
-const resolveCommand = __nccwpck_require__(5250);
-const escape = __nccwpck_require__(6868);
-const readShebang = __nccwpck_require__(7399);
-const semver = __nccwpck_require__(4774);
+const niceTry = __nccwpck_require__(7758);
+const resolveCommand = __nccwpck_require__(6084);
+const escape = __nccwpck_require__(1106);
+const readShebang = __nccwpck_require__(4877);
+const semver = __nccwpck_require__(4152);
 
 const isWin = process.platform === 'win32';
 const isExecutableRegExp = /\.(?:com|exe)$/i;
@@ -16676,7 +16676,7 @@ module.exports = parse;
 
 /***/ }),
 
-/***/ 6868:
+/***/ 1106:
 /***/ ((module) => {
 
 "use strict";
@@ -16729,14 +16729,14 @@ module.exports.argument = escapeArgument;
 
 /***/ }),
 
-/***/ 7399:
+/***/ 4877:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const fs = __nccwpck_require__(9896);
-const shebangCommand = __nccwpck_require__(5712);
+const shebangCommand = __nccwpck_require__(7722);
 
 function readShebang(command) {
     // Read the first 150 bytes from the file
@@ -16769,15 +16769,15 @@ module.exports = readShebang;
 
 /***/ }),
 
-/***/ 5250:
+/***/ 6084:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 
 const path = __nccwpck_require__(6928);
-const which = __nccwpck_require__(2400);
-const pathKey = __nccwpck_require__(177)();
+const which = __nccwpck_require__(522);
+const pathKey = __nccwpck_require__(5735)();
 
 function resolveCommandAttempt(parsed, withoutPathExt) {
     const cwd = process.cwd();
@@ -16824,7 +16824,7 @@ module.exports = resolveCommand;
 
 /***/ }),
 
-/***/ 5062:
+/***/ 4188:
 /***/ ((__unused_webpack_module, exports) => {
 
 "use strict";
@@ -16852,10 +16852,10 @@ exports.Deprecation = Deprecation;
 
 /***/ }),
 
-/***/ 384:
+/***/ 3850:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var once = __nccwpck_require__(5128);
+var once = __nccwpck_require__(5874);
 
 var noop = function() {};
 
@@ -16953,22 +16953,22 @@ module.exports = eos;
 
 /***/ }),
 
-/***/ 3324:
+/***/ 430:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const path = __nccwpck_require__(6928);
 const childProcess = __nccwpck_require__(5317);
-const crossSpawn = __nccwpck_require__(642);
-const stripEof = __nccwpck_require__(361);
-const npmRunPath = __nccwpck_require__(1171);
-const isStream = __nccwpck_require__(9791);
-const _getStream = __nccwpck_require__(5091);
-const pFinally = __nccwpck_require__(1246);
-const onExit = __nccwpck_require__(1840);
-const errname = __nccwpck_require__(8116);
-const stdio = __nccwpck_require__(4357);
+const crossSpawn = __nccwpck_require__(128);
+const stripEof = __nccwpck_require__(6559);
+const npmRunPath = __nccwpck_require__(1569);
+const isStream = __nccwpck_require__(3545);
+const _getStream = __nccwpck_require__(2417);
+const pFinally = __nccwpck_require__(1420);
+const onExit = __nccwpck_require__(7365);
+const errname = __nccwpck_require__(6974);
+const stdio = __nccwpck_require__(6907);
 
 const TEN_MEGABYTES = 1000 * 1000 * 10;
 
@@ -17322,7 +17322,7 @@ module.exports.shellSync = (cmd, opts) => handleShell(module.exports.sync, cmd, 
 
 /***/ }),
 
-/***/ 8116:
+/***/ 6974:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17369,7 +17369,7 @@ function errname(uv, code) {
 
 /***/ }),
 
-/***/ 4357:
+/***/ 6907:
 /***/ ((module) => {
 
 "use strict";
@@ -17418,7 +17418,7 @@ module.exports = opts => {
 
 /***/ }),
 
-/***/ 206:
+/***/ 4120:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -17477,13 +17477,13 @@ module.exports = options => {
 
 /***/ }),
 
-/***/ 5091:
+/***/ 2417:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-const pump = __nccwpck_require__(7994);
-const bufferStream = __nccwpck_require__(206);
+const pump = __nccwpck_require__(1988);
+const bufferStream = __nccwpck_require__(4120);
 
 class MaxBufferError extends Error {
 	constructor() {
@@ -17535,7 +17535,7 @@ module.exports.MaxBufferError = MaxBufferError;
 
 /***/ }),
 
-/***/ 7427:
+/***/ 4313:
 /***/ ((module) => {
 
 "use strict";
@@ -17591,7 +17591,7 @@ module.exports = isPlainObject;
 
 /***/ }),
 
-/***/ 9791:
+/***/ 3545:
 /***/ ((module) => {
 
 "use strict";
@@ -17620,15 +17620,15 @@ isStream.transform = function (stream) {
 
 /***/ }),
 
-/***/ 5516:
+/***/ 518:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 var fs = __nccwpck_require__(9896)
 var core
 if (process.platform === 'win32' || global.TESTING_WINDOWS) {
-  core = __nccwpck_require__(3705)
+  core = __nccwpck_require__(9035)
 } else {
-  core = __nccwpck_require__(8577)
+  core = __nccwpck_require__(8231)
 }
 
 module.exports = isexe
@@ -17684,7 +17684,7 @@ function sync (path, options) {
 
 /***/ }),
 
-/***/ 8577:
+/***/ 8231:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = isexe
@@ -17732,7 +17732,7 @@ function checkMode (stat, options) {
 
 /***/ }),
 
-/***/ 3705:
+/***/ 9035:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = isexe
@@ -17781,7 +17781,7 @@ function sync (path, options) {
 
 /***/ }),
 
-/***/ 167:
+/***/ 3521:
 /***/ ((module) => {
 
 /**
@@ -18719,7 +18719,7 @@ module.exports = get;
 
 /***/ }),
 
-/***/ 6059:
+/***/ 4637:
 /***/ ((module) => {
 
 /**
@@ -19716,7 +19716,7 @@ module.exports = set;
 
 /***/ }),
 
-/***/ 6508:
+/***/ 4674:
 /***/ ((module) => {
 
 /**
@@ -20619,7 +20619,7 @@ module.exports = uniq;
 
 /***/ }),
 
-/***/ 5745:
+/***/ 8571:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20659,7 +20659,7 @@ module.exports["default"] = macosRelease;
 
 /***/ }),
 
-/***/ 9224:
+/***/ 7758:
 /***/ ((module) => {
 
 "use strict";
@@ -20678,7 +20678,7 @@ module.exports = function(fn) {
 
 /***/ }),
 
-/***/ 3089:
+/***/ 1867:
 /***/ ((module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -20843,7 +20843,7 @@ FetchError.prototype.name = 'FetchError';
 
 let convert;
 try {
-	convert = (__nccwpck_require__(2272).convert);
+	convert = (__nccwpck_require__(9762).convert);
 } catch (e) {}
 
 const INTERNALS = Symbol('Body internals');
@@ -22328,13 +22328,13 @@ exports.FetchError = FetchError;
 
 /***/ }),
 
-/***/ 1171:
+/***/ 1569:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const path = __nccwpck_require__(6928);
-const pathKey = __nccwpck_require__(177);
+const pathKey = __nccwpck_require__(5735);
 
 module.exports = opts => {
 	opts = Object.assign({
@@ -22375,26 +22375,26 @@ module.exports.env = opts => {
 
 /***/ }),
 
-/***/ 2259:
+/***/ 6501:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = paginationMethodsPlugin
 
 function paginationMethodsPlugin (octokit) {
-  octokit.getFirstPage = (__nccwpck_require__(3246).bind)(null, octokit)
-  octokit.getLastPage = (__nccwpck_require__(5434).bind)(null, octokit)
-  octokit.getNextPage = (__nccwpck_require__(6297).bind)(null, octokit)
-  octokit.getPreviousPage = (__nccwpck_require__(1621).bind)(null, octokit)
-  octokit.hasFirstPage = __nccwpck_require__(7874)
-  octokit.hasLastPage = __nccwpck_require__(7830)
-  octokit.hasNextPage = __nccwpck_require__(765)
-  octokit.hasPreviousPage = __nccwpck_require__(2897)
+  octokit.getFirstPage = (__nccwpck_require__(7228).bind)(null, octokit)
+  octokit.getLastPage = (__nccwpck_require__(1804).bind)(null, octokit)
+  octokit.getNextPage = (__nccwpck_require__(2171).bind)(null, octokit)
+  octokit.getPreviousPage = (__nccwpck_require__(9475).bind)(null, octokit)
+  octokit.hasFirstPage = __nccwpck_require__(7576)
+  octokit.hasLastPage = __nccwpck_require__(1648)
+  octokit.hasNextPage = __nccwpck_require__(6023)
+  octokit.hasPreviousPage = __nccwpck_require__(7031)
 }
 
 
 /***/ }),
 
-/***/ 3732:
+/***/ 4762:
 /***/ ((module) => {
 
 module.exports = deprecate
@@ -22413,12 +22413,12 @@ function deprecate (message) {
 
 /***/ }),
 
-/***/ 3246:
+/***/ 7228:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getFirstPage
 
-const getPage = __nccwpck_require__(5719)
+const getPage = __nccwpck_require__(1833)
 
 function getFirstPage (octokit, link, headers) {
   return getPage(octokit, link, 'first', headers)
@@ -22427,12 +22427,12 @@ function getFirstPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 5434:
+/***/ 1804:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getLastPage
 
-const getPage = __nccwpck_require__(5719)
+const getPage = __nccwpck_require__(1833)
 
 function getLastPage (octokit, link, headers) {
   return getPage(octokit, link, 'last', headers)
@@ -22441,12 +22441,12 @@ function getLastPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 6297:
+/***/ 2171:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getNextPage
 
-const getPage = __nccwpck_require__(5719)
+const getPage = __nccwpck_require__(1833)
 
 function getNextPage (octokit, link, headers) {
   return getPage(octokit, link, 'next', headers)
@@ -22455,7 +22455,7 @@ function getNextPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 983:
+/***/ 9413:
 /***/ ((module) => {
 
 module.exports = getPageLinks
@@ -22477,14 +22477,14 @@ function getPageLinks (link) {
 
 /***/ }),
 
-/***/ 5719:
+/***/ 1833:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getPage
 
-const deprecate = __nccwpck_require__(3732)
-const getPageLinks = __nccwpck_require__(983)
-const HttpError = __nccwpck_require__(268)
+const deprecate = __nccwpck_require__(4762)
+const getPageLinks = __nccwpck_require__(9413)
+const HttpError = __nccwpck_require__(4502)
 
 function getPage (octokit, link, which, headers) {
   deprecate(`octokit.get${which.charAt(0).toUpperCase() + which.slice(1)}Page() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -22522,12 +22522,12 @@ function applyAcceptHeader (res, headers) {
 
 /***/ }),
 
-/***/ 1621:
+/***/ 9475:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = getPreviousPage
 
-const getPage = __nccwpck_require__(5719)
+const getPage = __nccwpck_require__(1833)
 
 function getPreviousPage (octokit, link, headers) {
   return getPage(octokit, link, 'prev', headers)
@@ -22536,13 +22536,13 @@ function getPreviousPage (octokit, link, headers) {
 
 /***/ }),
 
-/***/ 7874:
+/***/ 7576:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasFirstPage
 
-const deprecate = __nccwpck_require__(3732)
-const getPageLinks = __nccwpck_require__(983)
+const deprecate = __nccwpck_require__(4762)
+const getPageLinks = __nccwpck_require__(9413)
 
 function hasFirstPage (link) {
   deprecate(`octokit.hasFirstPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -22552,13 +22552,13 @@ function hasFirstPage (link) {
 
 /***/ }),
 
-/***/ 7830:
+/***/ 1648:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasLastPage
 
-const deprecate = __nccwpck_require__(3732)
-const getPageLinks = __nccwpck_require__(983)
+const deprecate = __nccwpck_require__(4762)
+const getPageLinks = __nccwpck_require__(9413)
 
 function hasLastPage (link) {
   deprecate(`octokit.hasLastPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -22568,13 +22568,13 @@ function hasLastPage (link) {
 
 /***/ }),
 
-/***/ 765:
+/***/ 6023:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasNextPage
 
-const deprecate = __nccwpck_require__(3732)
-const getPageLinks = __nccwpck_require__(983)
+const deprecate = __nccwpck_require__(4762)
+const getPageLinks = __nccwpck_require__(9413)
 
 function hasNextPage (link) {
   deprecate(`octokit.hasNextPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -22584,13 +22584,13 @@ function hasNextPage (link) {
 
 /***/ }),
 
-/***/ 2897:
+/***/ 7031:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = hasPreviousPage
 
-const deprecate = __nccwpck_require__(3732)
-const getPageLinks = __nccwpck_require__(983)
+const deprecate = __nccwpck_require__(4762)
+const getPageLinks = __nccwpck_require__(9413)
 
 function hasPreviousPage (link) {
   deprecate(`octokit.hasPreviousPage() – You can use octokit.paginate or async iterators instead: https://github.com/octokit/rest.js#pagination.`)
@@ -22600,7 +22600,7 @@ function hasPreviousPage (link) {
 
 /***/ }),
 
-/***/ 268:
+/***/ 4502:
 /***/ ((module) => {
 
 module.exports = class HttpError extends Error {
@@ -22622,10 +22622,10 @@ module.exports = class HttpError extends Error {
 
 /***/ }),
 
-/***/ 5128:
+/***/ 5874:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var wrappy = __nccwpck_require__(7752)
+var wrappy = __nccwpck_require__(8834)
 module.exports = wrappy(once)
 module.exports.strict = wrappy(onceStrict)
 
@@ -22671,14 +22671,14 @@ function onceStrict (fn) {
 
 /***/ }),
 
-/***/ 630:
+/***/ 5968:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const os = __nccwpck_require__(857);
-const macosRelease = __nccwpck_require__(5745);
-const winRelease = __nccwpck_require__(8777);
+const macosRelease = __nccwpck_require__(8571);
+const winRelease = __nccwpck_require__(3923);
 
 const osName = (platform, release) => {
 	if (!platform && release) {
@@ -22725,7 +22725,7 @@ module.exports = osName;
 
 /***/ }),
 
-/***/ 1246:
+/***/ 1420:
 /***/ ((module) => {
 
 "use strict";
@@ -22748,7 +22748,7 @@ module.exports = (promise, onFinally) => {
 
 /***/ }),
 
-/***/ 177:
+/***/ 5735:
 /***/ ((module) => {
 
 "use strict";
@@ -22769,11 +22769,11 @@ module.exports = opts => {
 
 /***/ }),
 
-/***/ 7994:
+/***/ 1988:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-var once = __nccwpck_require__(5128)
-var eos = __nccwpck_require__(384)
+var once = __nccwpck_require__(5874)
+var eos = __nccwpck_require__(3850)
 var fs = __nccwpck_require__(9896) // we only need fs to get the ReadStream and WriteStream prototypes
 
 var noop = function () {}
@@ -22858,7 +22858,7 @@ module.exports = pump
 
 /***/ }),
 
-/***/ 4774:
+/***/ 4152:
 /***/ ((module, exports) => {
 
 exports = module.exports = SemVer
@@ -24348,12 +24348,12 @@ function coerce (version) {
 
 /***/ }),
 
-/***/ 5712:
+/***/ 7722:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
-var shebangRegex = __nccwpck_require__(5862);
+var shebangRegex = __nccwpck_require__(3900);
 
 module.exports = function (str) {
 	var match = str.match(shebangRegex);
@@ -24375,7 +24375,7 @@ module.exports = function (str) {
 
 /***/ }),
 
-/***/ 5862:
+/***/ 3900:
 /***/ ((module) => {
 
 "use strict";
@@ -24385,14 +24385,14 @@ module.exports = /^#!.*/;
 
 /***/ }),
 
-/***/ 1840:
+/***/ 7365:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 // Note: since nyc uses this module to output coverage, any lines
 // that are in the direct sync flow of nyc's outputCoverage are
 // ignored, since we can never get coverage for them.
 var assert = __nccwpck_require__(2613)
-var signals = __nccwpck_require__(9510)
+var signals = __nccwpck_require__(7468)
 var isWin = /^win/i.test(process.platform)
 
 var EE = __nccwpck_require__(4434)
@@ -24555,7 +24555,7 @@ function processEmit (ev, arg) {
 
 /***/ }),
 
-/***/ 9510:
+/***/ 7468:
 /***/ ((module) => {
 
 // This is not the set of all possible signals.
@@ -24615,7 +24615,7 @@ if (process.platform === 'linux') {
 
 /***/ }),
 
-/***/ 361:
+/***/ 6559:
 /***/ ((module) => {
 
 "use strict";
@@ -24638,15 +24638,15 @@ module.exports = function (x) {
 
 /***/ }),
 
-/***/ 4578:
+/***/ 2060:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
-module.exports = __nccwpck_require__(2826);
+module.exports = __nccwpck_require__(556);
 
 
 /***/ }),
 
-/***/ 2826:
+/***/ 556:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24918,7 +24918,7 @@ exports.debug = debug; // for test
 
 /***/ }),
 
-/***/ 4435:
+/***/ 3189:
 /***/ ((__unused_webpack_module, exports, __nccwpck_require__) => {
 
 "use strict";
@@ -24928,7 +24928,7 @@ Object.defineProperty(exports, "__esModule", ({ value: true }));
 
 function _interopDefault (ex) { return (ex && (typeof ex === 'object') && 'default' in ex) ? ex['default'] : ex; }
 
-var osName = _interopDefault(__nccwpck_require__(630));
+var osName = _interopDefault(__nccwpck_require__(5968));
 
 function getUserAgent() {
   try {
@@ -24948,7 +24948,7 @@ exports.getUserAgent = getUserAgent;
 
 /***/ }),
 
-/***/ 2400:
+/***/ 522:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 module.exports = which
@@ -24960,7 +24960,7 @@ var isWindows = process.platform === 'win32' ||
 
 var path = __nccwpck_require__(6928)
 var COLON = isWindows ? ';' : ':'
-var isexe = __nccwpck_require__(5516)
+var isexe = __nccwpck_require__(518)
 
 function getNotFoundError (cmd) {
   var er = new Error('not found: ' + cmd)
@@ -25090,13 +25090,13 @@ function whichSync (cmd, opt) {
 
 /***/ }),
 
-/***/ 8777:
+/***/ 3923:
 /***/ ((module, __unused_webpack_exports, __nccwpck_require__) => {
 
 "use strict";
 
 const os = __nccwpck_require__(857);
-const execa = __nccwpck_require__(3324);
+const execa = __nccwpck_require__(430);
 
 // Reference: https://www.gaijin.at/en/lstwinver.php
 const names = new Map([
@@ -25150,7 +25150,7 @@ module.exports = windowsRelease;
 
 /***/ }),
 
-/***/ 7752:
+/***/ 8834:
 /***/ ((module) => {
 
 // Returns a wrapper function that returns a wrapped callback
@@ -25190,7 +25190,7 @@ function wrappy (fn, cb) {
 
 /***/ }),
 
-/***/ 2272:
+/***/ 9762:
 /***/ ((module) => {
 
 module.exports = eval("require")("encoding");
@@ -25362,9 +25362,9 @@ var __webpack_exports__ = {};
 "use strict";
 
 // EXTERNAL MODULE: ./node_modules/@actions/core/lib/core.js
-var core = __nccwpck_require__(1836);
+var core = __nccwpck_require__(4406);
 // EXTERNAL MODULE: ./node_modules/@actions/github/lib/github.js
-var github = __nccwpck_require__(5404);
+var github = __nccwpck_require__(190);
 ;// CONCATENATED MODULE: ./labeler.ts
 var __awaiter = (undefined && undefined.__awaiter) || function (thisArg, _arguments, P, generator) {
     function adopt(value) { return value instanceof P ? value : new P(function (resolve) { resolve(value); }); }
@@ -25536,6 +25536,10 @@ function handleStatusEvent(client, payload) {
         for (const branch of branches) {
             const pulls = yield client.pulls.list({ owner, repo, state: "open", head: `${owner}:${branch.name}` });
             for (const pull of pulls.data) {
+                if (pull.draft) {
+                    console.log(`Skipping draft PR #${pull.number} for branch '${branch.name}'.`);
+                    continue;
+                }
                 console.log(`Found open PR #${pull.number} for branch '${branch.name}'.`);
                 yield labelPullRequestAndLinkedIssues(client, pull.number, pull.body, reviewLabel);
             }

--- a/index.ts
+++ b/index.ts
@@ -75,6 +75,10 @@ async function handleStatusEvent(client: github.GitHub, payload: WebhookPayload)
   for (const branch of branches) {
     const pulls = await client.pulls.list({ owner, repo, state: "open", head: `${owner}:${branch.name}` });
     for (const pull of pulls.data) {
+      if (pull.draft) {
+        console.log(`Skipping draft PR #${pull.number} for branch '${branch.name}'.`);
+        continue;
+      }
       console.log(`Found open PR #${pull.number} for branch '${branch.name}'.`);
       await labelPullRequestAndLinkedIssues(client, pull.number, pull.body, reviewLabel);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlightLoggerLabelAction",
-  "version": "1.0.0",
+  "version": "1.7.1",
   "main": "index.js",
   "repository": "git@github.com:Jensenks/FlightLoggerLabelAction.git",
   "author": "Kåre Jensen <jensenks@gmail.com>",


### PR DESCRIPTION
## Summary
- Draft PRs no longer receive the `6: PR for review` label when CI turns green
- Checks `pull.draft` before applying the review label in the `status` event handler, skipping draft PRs with a log message

## Test plan
- [ ] Push a commit to a branch with a draft PR and verify the review label is **not** applied when CI succeeds
- [ ] Push a commit to a branch with a non-draft PR and verify the review label **is** applied as before
- [ ] Mark a draft PR as ready for review, push a new commit, and verify the label is applied


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Draft pull requests are now skipped when applying labels, preventing unintended updates for work that isn’t ready for review.
  * The system now notes when a draft PR is intentionally ignored.
* **Chores**
  * Updated the package version to **1.7.1**.
  * Updated ignore rules to exclude `lib/` and `.idea/`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->